### PR TITLE
Add class to exand flattened arrays

### DIFF
--- a/src/Expand.php
+++ b/src/Expand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sarhan;
+
+/**
+ * @author  Frank Koornstra
+ * @license LGPL
+ */
+class Expand
+{
+    /**
+     * Expands a one-dimensional array that has flattened keys to a (possibly) multi-dimensional array
+     */
+    public static function inflate(array $array, string $separator = '.'): array
+    {
+        $inflated = [];
+
+        foreach ($array as $key => $value) {
+            $parent = &$inflated;
+
+            $partList = explode($separator, $key);
+            $leafPart = array_pop($partList);
+
+            foreach ($partList as $part) {
+                if (! isset($parent[$part]) || ! is_array($parent[$part])) {
+                    $parent[$part] = [];
+                }
+                $parent = &$parent[$part];
+            }
+
+            if (empty($parent[$leafPart])) {
+                $parent[$leafPart] = $value;
+            }
+        }
+
+        return $inflated;
+    }
+}

--- a/test/ExpandTest.php
+++ b/test/ExpandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Sarhan\Expand;
+
+class ExpandTest extends TestCase
+{
+    public function provideInflationData()
+    {
+        return [
+            'simple non-nested' => [
+                [
+                    'foo' => 'bar',
+                ],
+                [
+                    'foo' => 'bar',
+                ],
+            ],
+            'simple nested' => [
+                [
+                    'foo.first' => 'bar',
+                ],
+                [
+                    'foo' => [
+                        'first' => 'bar',
+                    ],
+                ],
+            ],
+            'nested with different keys on one level' =>[
+                [
+                    'foo.first' => 'bar',
+                    'foo.second' => 'bla',
+                ],
+                [
+                    'foo' => [
+                        'first' => 'bar',
+                        'second' => 'bla',
+                    ],
+                ],
+            ],
+
+            'nested on multiple levels' => [
+                [
+                    'foo.first.second' => 'bar',
+                ],
+                [
+                    'foo' => [
+                        'first' => ['second' => 'bar'],
+                    ],
+                ],
+            ],
+            'nested with conflicting array and simple value for one key favours array' =>[
+                [
+                    'foo' => 'bloo',
+                    'foo.first' => 'bar',
+                    'foo.second' => 'bla',
+                ],
+                [
+                    'foo' => [
+                        'first' => 'bar',
+                        'second' => 'bla',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInflationData
+     */
+    public function testInflate($input, $expectedOutput)
+    {
+        $actualOutput = Expand::inflate($input);
+
+        self::assertEquals($expectedOutput, $actualOutput);
+    }
+}


### PR DESCRIPTION
A minimal implementation to expand arrays with flattened keys to reverse
the Flatten::flatten() result.

This implementation does not cover all reverse cases that the Flatten
class presents in its tests but does solve a very common case.